### PR TITLE
*: add "gofail-go" for manual "Release" call

### DIFF
--- a/code/binding.go
+++ b/code/binding.go
@@ -40,10 +40,12 @@ func (b *Binding) Write(dst io.Writer) error {
 	for _, fp := range b.fps {
 		_, err := fmt.Fprintf(
 			dst,
-			"var %s *runtime.Failpoint = runtime.NewFailpoint(%q, %q)\n",
+			"var %s *runtime.Failpoint = runtime.NewFailpoint(%q, %q, %v)\n",
 			fp.Runtime(),
 			b.fppath,
-			fp.Name())
+			fp.Name(),
+			fp.goFailGo,
+		)
 		if err != nil {
 			return err
 		}

--- a/code/rewrite_test.go
+++ b/code/rewrite_test.go
@@ -46,6 +46,18 @@ func f() {
 	}
 }
 `, 1},
+	{`
+	func f() {
+		// gofail: labelTest:
+		for {
+			if g() {
+				// gofail-go: var testLabel struct{}
+				// continue labelTest
+				return
+			}
+		}
+	}
+	`, 1},
 }
 
 func TestToFailpoint(t *testing.T) {

--- a/examples/cmd/cmd.go
+++ b/examples/cmd/cmd.go
@@ -21,9 +21,23 @@ import (
 	"github.com/coreos/gofail/examples"
 )
 
+/*
+GOFAIL_HTTP=:22381 go run cmd.go
+
+curl -L http://localhost:22381
+
+curl \
+  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabelsGo \
+  -X PUT -d'return'
+
+curl \
+  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabelsGo \
+  -X DELETE
+*/
+
 func main() {
 	for {
-		log.Println(examples.ExampleFunc())
+		log.Println(examples.ExampleLabelsGoFunc())
 		time.Sleep(time.Second)
 	}
 }

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -39,3 +39,18 @@ func ExampleLabelsFunc() (s string) {
 	}
 	return s
 }
+
+func ExampleLabelsGoFunc() (s string) {
+	i := 0
+	// gofail: myLabel:
+	for i < 5 {
+		s = s + "i"
+		i++
+		for j := 0; j < 5; j++ {
+			s = s + "j"
+			// gofail-go: var ExampleLabelsGo struct{}
+			// continue myLabel
+		}
+	}
+	return s
+}


### PR DESCRIPTION
To address https://github.com/coreos/gofail/issues/14.

ref. https://github.com/coreos/gofail/pull/12 and https://github.com/coreos/gofail/pull/13.

/cc @heyitsanthony 

To reiterate etcd use case, we want to simulate leader heartbeat drop in incoming traffic:

```diff
iff --git a/etcdserver/api/rafthttp/stream.go b/etcdserver/api/rafthttp/stream.go
index f6cda71a3..b8795bff0 100644
--- a/etcdserver/api/rafthttp/stream.go
+++ b/etcdserver/api/rafthttp/stream.go
@@ -510,6 +510,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
        }
        cr.mu.Unlock()
 
+       // gofail: labelRaftDropHeartbeat:
        for {
                m, err := dec.decode()
                if err != nil {
@@ -519,6 +520,8 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
                        return err
                }
 
+               // gofail-go: var raftDropHeartbeat struct{}
+               // continue labelRaftDropHeartbeat
                receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(m.Size()))
 
                cr.mu.Lock()
```

With this patch, `gofail enable` would output:

```diff
diff --git a/etcdserver/api/rafthttp/stream.go b/etcdserver/api/rafthttp/stream.go
index b8795bff0..543ada74f 100644
--- a/etcdserver/api/rafthttp/stream.go
+++ b/etcdserver/api/rafthttp/stream.go
@@ -510,7 +510,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
        }
        cr.mu.Unlock()
 
-       // gofail: labelRaftDropHeartbeat:
+       /* gofail-label */ labelRaftDropHeartbeat:
        for {
                m, err := dec.decode()
                if err != nil {
@@ -520,8 +520,8 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
                        return err
                }
 
-               // gofail-go: var raftDropHeartbeat struct{}
-               // continue labelRaftDropHeartbeat
+               if vraftDropHeartbeat, __fpGoErr := __fp_raftDropHeartbeat.Acquire(); __fpGoErr == nil { go __fp_raftDropHeartbeat.Release(); _, __fpTypeOK := vraftDropHeartbeat.(struct{}); if !__fpTypeOK { goto __badTyperaftDropHeartbeat} 
+                        continue labelRaftDropHeartbeat; __badTyperaftDropHeartbeat: __fp_raftDropHeartbeat.BadType(vraftDropHeartbeat, "struct{}"); };
                receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(m.Size()))
 
                cr.mu.Lock()
```

Now, `*Failpoint.Release` will be waiting to be triggered in a goroutine, instead of never being called with `defer` (triggered when `gofail` disables the corresponding `Failpoint`). This adds `released bool` field to safely release multiple goroutines.

https://github.com/coreos/gofail/issues/14#issuecomment-384362421 originally suggested

> `// gofail-go:` to indicate that a delete will prevent new fp's from being issued, but has no control over whether any are inflight.

This PR's `// gofail-go:` *does* control queued `Release` calls. Once disabled, it will prevent new failpoints from being issued. This PR tries to enable manual `Release` calls via disable request, because without control over inflight `Release` calls, the write lock for disable request would block, thus unable to delete the failpoints in the first place.
