### PR TITLE
fix noise log when fallthrough from gofail's if block

### DIFF
--- a/code/failpoint.go
+++ b/code/failpoint.go
@@ -64,8 +64,8 @@ func (fp *Failpoint) hdr(varname string) string {
 }
 
 func (fp *Failpoint) footer() string {
-	return "; __badType" + fp.name + ": " +
-		fp.Runtime() + ".BadType(v" + fp.name + ", \"" + fp.varType + "\"); };"
+	return "; goto __nomock" + fp.name + "; __badType" + fp.name + ": " +
+		fp.Runtime() + ".BadType(v" + fp.name + ", \"" + fp.varType + "\"); __nomock" + fp.name + ": };"
 }
 
 func (fp *Failpoint) flushSingle(dst io.Writer) error {

--- a/code/rewrite.go
+++ b/code/rewrite.go
@@ -87,7 +87,7 @@ func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
 			unmatchedBraces += opening - closing
 			if unmatchedBraces == 0 {
 				// strip off badType footer
-				lTrim = strings.Split(lTrim, "; __badType")[0]
+				lTrim = strings.Split(lTrim, "; goto __nomock")[0]
 			}
 			s := ws + "//" + wsPrefix(l, ws)[1:] + lTrim + "\n"
 			dst.WriteString(s)
@@ -100,7 +100,7 @@ func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
 			n := strings.Split(strings.Split(l, "__fp_")[1], ".")[0]
 			t := strings.Split(strings.Split(l, ".(")[1], ")")[0]
 			dst.WriteString(ws + "// gofail: var " + n + " " + t + "\n")
-			if !strings.Contains(l, "; __badType") {
+			if !strings.Contains(l, "; goto __nomock") {
 				// not single liner
 				unmatchedBraces = 1
 			}


### PR DESCRIPTION
### how to reproduce

#### what I do

```
import "fmt"

func Test() string {
	// gofail: var beFail bool
	// if beFail {
	// 	fmt.Print(1)
	// }
	fmt.Println(2)
	return "ok"
}
```
and enable gofail and return `false` by

```
import (
	gofail "github.com/etcd-io/gofail/runtime"
)

func TestGoFail(t *testing.T) {
	gofail.Enable("github.com/lysu/go-misc/fail/beFail", "return(false)")
	defer gofail.Disable("github.com/lysu/go-misc/fail/beFail")
	t.Log(fail.Test())
}
```
#### expect

print 2 and return ok

#### but got

std log message
```
failpoint: "github.com/lysu/go-misc/fail/beFail" got value false of type "bool" but expected type "bool"
```
and print 2 and return ok

### what question

generate code after `gofail enable` will be 

```
func Test() string {
	if vbeFail, __fpErr := __fp_beFail.Acquire(); __fpErr == nil { defer __fp_beFail.Release(); beFail, __fpTypeOK := vbeFail.(bool); if !__fpTypeOK { goto __badTypebeFail}
		if beFail {
			fmt.Print(1)
		}; __badTypebeFail: __fp_beFail.BadType(vbeFail, "bool"); };
	fmt.Println(2)
	return "ok"
}
```
when `beFail` as `false`, it will continue execute  `__fp_beFail.BadType(vbeFail, "bool");` event if there are no type error.

### what I fix

to generate this code:

```
func Test() string {
	if vbeFail, __fpErr := __fp_beFail.Acquire(); __fpErr == nil { defer __fp_beFail.Release(); beFail, __fpTypeOK := vbeFail.(bool); if !__fpTypeOK { goto __badTypebeFail}
		if beFail {
			fmt.Print(1)
		}; goto __nomockbeFail; __badTypebeFail: __fp_beFail.BadType(vbeFail, "bool"); __nomockbeFail: };
	fmt.Println(2)
	return "ok"
}
```
