### PR TITLE
Replace io/ioutil with io

### DIFF
--- a/runtime/http.go
+++ b/runtime/http.go
@@ -15,7 +15,7 @@
 package runtime
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sort"
@@ -44,7 +44,7 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	// sets the failpoint
 	case r.Method == "PUT":
-		v, err := ioutil.ReadAll(r.Body)
+		v, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "failed ReadAll in PUT", http.StatusBadRequest)
 			return


### PR DESCRIPTION
The io/ioutil has already been deprecated in golang 1.16.
Refer to [replace_ioutil](https://go.dev/doc/go1.16#ioutil) .

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @spzala 