### PR TITLE
fix golangci-lint errors

### DIFF
--- a/code/rewrite_test.go
+++ b/code/rewrite_test.go
@@ -82,14 +82,17 @@ func TestToComment(t *testing.T) {
 	for i, ex := range examples {
 		dst := bytes.NewBuffer(make([]byte, 0, 1024))
 		src := strings.NewReader(ex.code)
-		fps, err := ToFailpoints(dst, src)
+		_, err := ToFailpoints(dst, src)
 		if err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
 
 		src = strings.NewReader(dst.String())
 		dst.Reset()
-		fps, err = ToComments(dst, src)
+		fps, err := ToComments(dst, src)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		plainCode := dst.String()
 
 		if plainCode != ex.code {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -37,12 +37,12 @@ func init() {
 	if s := os.Getenv("GOFAIL_FAILPOINTS"); len(s) > 0 {
 		// format is <FAILPOINT>=<TERMS>[;<FAILPOINT>=<TERMS>;...]
 		for _, fp := range strings.Split(s, ";") {
-			fp_term := strings.Split(fp, "=")
-			if len(fp_term) != 2 {
+			fpTerm := strings.Split(fp, "=")
+			if len(fpTerm) != 2 {
 				fmt.Printf("bad failpoint %q\n", fp)
 				os.Exit(1)
 			}
-			envTerms[fp_term[0]] = fp_term[1]
+			envTerms[fpTerm[0]] = fpTerm[1]
 		}
 	}
 	if s := os.Getenv("GOFAIL_HTTP"); len(s) > 0 {


### PR DESCRIPTION
Fix golangci-lint errors below,
```
  Running [/home/runner/golangci-lint-1.29.0-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  Error: ineffectual assignment to `fps` (ineffassign)
  Error: ineffectual assignment to `err` (ineffassign)
  Error: ST1003: should not use underscores in Go names; var fp_term should be fpTerm (stylecheck)
  
  Error: issues found
  Ran golangci-lint in 805ms
```

Refer to https://github.com/etcd-io/gofail/runs/8025843669?check_suite_focus=true 

Signed-off-by: Benjamin Wang <wachao@vmware.com>