### PR TITLE
runtime: close(donec) to elimanate deadlock

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -96,7 +96,7 @@ func Disable(failpath string) error {
 	fp.cmu.RUnlock()
 	if cancel != nil && donec != nil {
 		cancel()
-		<-donec
+		close(donec)
 
 		fp.cmu.Lock()
 		fp.ctx, fp.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
implemented: close(donec) to properly disable failpoint in runtime.go 

Signed-off-by: Ramil Mirhasanov <ramil600@yahoo.com>