### PR TITLE
remove gofail-go failpoint

### DIFF
--- a/code/binding.go
+++ b/code/binding.go
@@ -40,11 +40,10 @@ func (b *Binding) Write(dst io.Writer) error {
 	for _, fp := range b.fps {
 		_, err := fmt.Fprintf(
 			dst,
-			"var %s *runtime.Failpoint = runtime.NewFailpoint(%q, %q, %v)\n",
+			"var %s *runtime.Failpoint = runtime.NewFailpoint(%q, %q)\n",
 			fp.Runtime(),
 			b.fppath,
 			fp.Name(),
-			fp.goFailGo,
 		)
 		if err != nil {
 			return err

--- a/code/rewrite.go
+++ b/code/rewrite.go
@@ -26,10 +26,6 @@ const (
 	pfxGofail    = `// gofail:`
 	labelGofail  = `/* gofail-label */`
 	errVarGoFail = `__fpErr`
-
-	pfxGofailGo    = `// gofail-go:`
-	labelGofailGo  = `/* gofail-go-label */`
-	errVarGoFailGo = `__fpGoErr`
 )
 
 // ToFailpoints turns all gofail comments into failpoint code. Returns a list of
@@ -63,9 +59,6 @@ func ToFailpoints(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) 
 				curfp = nil
 			}
 		} else if label := gofailLabel(l, pfxGofail, labelGofail); label != "" {
-			// expose gofail label
-			l = label
-		} else if label := gofailLabel(l, pfxGofailGo, labelGofailGo); label != "" {
 			// expose gofail label
 			l = label
 		} else if curfp, err = newFailpoint(l); err != nil {
@@ -109,13 +102,10 @@ func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
 		}
 
 		isErrVarGoFail := strings.Contains(l, fmt.Sprintf(", %s := __fp_", errVarGoFail))
-		isErrVarGoFailGo := strings.Contains(l, fmt.Sprintf(", %s := __fp_", errVarGoFailGo))
-		isHdr := (isErrVarGoFail || isErrVarGoFailGo) && strings.HasPrefix(lTrim, "if")
+		isHdr := isErrVarGoFail && strings.HasPrefix(lTrim, "if")
 		if isHdr {
 			pfx := pfxGofail
-			if isErrVarGoFailGo {
-				pfx = pfxGofailGo
-			}
+
 			ws = strings.Split(l, "i")[0]
 			n := strings.Split(strings.Split(l, "__fp_")[1], ".")[0]
 			t := strings.Split(strings.Split(l, ".(")[1], ")")[0]
@@ -130,9 +120,6 @@ func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
 
 		if isLabel := strings.Contains(l, "\t"+labelGofail); isLabel {
 			l = strings.Replace(l, labelGofail, pfxGofail, 1)
-		}
-		if isLabel := strings.Contains(l, "\t"+labelGofailGo); isLabel {
-			l = strings.Replace(l, labelGofailGo, pfxGofailGo, 1)
 		}
 
 		if _, werr := dst.WriteString(l); werr != nil {

--- a/code/rewrite_test.go
+++ b/code/rewrite_test.go
@@ -46,18 +46,6 @@ func f() {
 	}
 }
 `, 1},
-	{`
-	func f() {
-		// gofail: labelTest:
-		for {
-			if g() {
-				// gofail-go: var testLabel struct{}
-				// continue labelTest
-				return
-			}
-		}
-	}
-	`, 1},
 }
 
 func TestToFailpoint(t *testing.T) {

--- a/examples/cmd/cmd.go
+++ b/examples/cmd/cmd.go
@@ -27,17 +27,17 @@ GOFAIL_HTTP=:22381 go run cmd.go
 curl -L http://localhost:22381
 
 curl \
-  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabelsGo \
+  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabels \
   -X PUT -d'return'
 
 curl \
-  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabelsGo \
+  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabels \
   -X DELETE
 */
 
 func main() {
 	for {
-		log.Println(examples.ExampleLabelsGoFunc())
+		log.Println(examples.ExampleLabelsFunc())
 		time.Sleep(time.Second)
 	}
 }

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -39,18 +39,3 @@ func ExampleLabelsFunc() (s string) {
 	}
 	return s
 }
-
-func ExampleLabelsGoFunc() (s string) {
-	i := 0
-	// gofail-go: myLabel:
-	for i < 5 {
-		s = s + "i"
-		i++
-		for j := 0; j < 5; j++ {
-			s = s + "j"
-			// gofail-go: var ExampleLabelsGo struct{}
-			// continue myLabel
-		}
-	}
-	return s
-}


### PR DESCRIPTION
My understanding is the main motivation to introduce gofail-go failpoint is to make sure it can't be updated by users once it's triggered. Instead, users have to delete/disable it firstly, and then set another term for the gofail-go failpoint.

Two points:
1. The gofail-go's Release is called in a separate goroutine, it might cause goroutine leak.
2. It complicates the overall design & implementation without obvious benefit.

Signed-off-by: Benjamin Wang <wachao@vmware.com>