### PR TITLE
`gofail --version` should exit with 0

### DIFF
--- a/gofail.go
+++ b/gofail.go
@@ -183,11 +183,7 @@ func main() {
 	case "disable":
 		xfrm = code.ToComments
 	case "--version":
-		fmt.Println("Git SHA: ", GitSHA)
-		fmt.Println("Go Version: ", runtime.Version())
-		fmt.Println("gofail Version: ", Version)
-		fmt.Printf("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-		os.Exit(1)
+		showVersion()
 	default:
 		fmt.Println(usageLine)
 		os.Exit(1)
@@ -216,4 +212,12 @@ func main() {
 			os.Remove(path.Join(path.Dir(files[i]), fname))
 		}
 	}
+}
+
+func showVersion() {
+	fmt.Println("Git SHA: ", GitSHA)
+	fmt.Println("Go Version: ", runtime.Version())
+	fmt.Println("gofail Version: ", Version)
+	fmt.Printf("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	os.Exit(0)
 }


### PR DESCRIPTION
The issue was introduced in https://github.com/etcd-io/gofail/pull/35. The command `gofail --version` exits with code 1. It isn't correct. Instead, it should exit with 0. 

When executing `make`, it always display an error like below,

$ make
GO_BUILD_FLAGS="-v" ./build.sh
go.etcd.io/gofail/code
go.etcd.io/gofail
./gofail --version
Git SHA:  dc004b5
Go Version:  go1.19.2
gofail Version:  0.1.0
Go OS/Arch: linux/amd64
make: *** [gofail] Error 1

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @spzala @ramil600 