### PR TITLE
Support dynamically setting multiple failpoints

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -48,12 +48,22 @@ The static way is to set [gofail terms](#gofail-term) using environment variable
 $ GOFAIL_FAILPOINTS='my/package/path/SomeFuncString=sleep("600s")' ./cmd
 ```
 
+You can set multiple failpoints by using ";" as the delimiter,
+```
+GOFAIL_FAILPOINTS='failpoint1=return("hello");failpoint2=sleep(10)' ./cmd
+```
+
 The dynamic way is to set an HTTP endpoint using environment variable `GOFAIL_HTTP` when starting your application, 
 and add [gofail terms](#gofail-term) via the endpoint afterwards. See example below,
 ```
 $ GOFAIL_HTTP="127.0.0.1:22381" ./cmd
 
 $ curl http://127.0.0.1:22381/my/package/path/SomeFuncString -XPUT -d'sleep("600s")'
+```
+
+Similarly, you can set multiple failpoints using endpoint `/failpoints`,
+```
+curl http://127.0.0.1:22381/failpoints -X PUT -d'failpoint1=return("hello");failpoint2=sleep(10)'
 ```
 
 ## Generated code

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module go.etcd.io/gofail
 
 go 1.17
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/runtime/failpoint.go
+++ b/runtime/failpoint.go
@@ -16,12 +16,10 @@ package runtime
 
 import (
 	"fmt"
-	"sync"
 )
 
 type Failpoint struct {
-	mu sync.RWMutex
-	t  *terms
+	t *terms
 }
 
 func NewFailpoint(pkg, name string) *Failpoint {
@@ -33,24 +31,19 @@ func NewFailpoint(pkg, name string) *Failpoint {
 // Acquire gets evalutes the failpoint terms; if the failpoint
 // is active, it will return a value. Otherwise, returns a non-nil error.
 func (fp *Failpoint) Acquire() (interface{}, error) {
-	fp.mu.RLock()
 	if fp.t == nil {
-		fp.mu.RUnlock()
 		return nil, ErrDisabled
 	}
 	v, err := fp.t.eval()
 	if v == nil {
 		err = ErrDisabled
 	}
-	if err != nil {
-		fp.mu.RUnlock()
-	}
 	return v, err
 }
 
 // Release is called when the failpoint exists.
+// TODO(ahrtr): remove Release from template
 func (fp *Failpoint) Release() {
-	fp.mu.RUnlock()
 }
 
 // BadType is called when the failpoint evaluates to the wrong type.

--- a/runtime/failpoint.go
+++ b/runtime/failpoint.go
@@ -31,6 +31,9 @@ func NewFailpoint(pkg, name string) *Failpoint {
 // Acquire gets evalutes the failpoint terms; if the failpoint
 // is active, it will return a value. Otherwise, returns a non-nil error.
 func (fp *Failpoint) Acquire() (interface{}, error) {
+	failpointsMu.RLock()
+	defer failpointsMu.RUnlock()
+
 	if fp.t == nil {
 		return nil, ErrDisabled
 	}

--- a/runtime/http.go
+++ b/runtime/http.go
@@ -43,6 +43,8 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// at a time, so it (the efficiency) isn't a problem.
 	failpointsMu.Lock()
 	defer failpointsMu.Unlock()
+	// flush before unlocking so a panic failpoint won't
+	// take down the http server before it sends the response
 	defer flush(w)
 
 	key := r.RequestURI
@@ -114,8 +116,6 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func flush(w http.ResponseWriter) {
 	if f, ok := w.(http.Flusher); ok {
-		// flush before unlocking so a panic failpoint won't
-		// take down the http server before it sends the response
 		f.Flush()
 	}
 }

--- a/runtime/http.go
+++ b/runtime/http.go
@@ -15,6 +15,7 @@
 package runtime
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -34,6 +35,15 @@ func serve(host string) error {
 }
 
 func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// This prevents all failpoints from being triggered. It ensures
+	// the server(runtime) doesn't panic due to any failpoints during
+	// processing the HTTP request.
+	// It may be inefficient, but correctness is more important than
+	// efficiency. Usually users will not enable too many failpoints
+	// at a time, so it (the efficiency) isn't a problem.
+	failpointsMu.Lock()
+	defer failpointsMu.Unlock()
+
 	key := r.RequestURI
 	if len(key) == 0 || key[0] != '/' {
 		http.Error(w, "malformed request URI", http.StatusBadRequest)
@@ -49,51 +59,72 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed ReadAll in PUT", http.StatusBadRequest)
 			return
 		}
-		Lock()
-		eerr := enable(key, string(v))
-		if eerr != nil {
-			UnLock()
-			http.Error(w, "failed to set failpoint "+string(key), http.StatusBadRequest)
-			return
+
+		fpMap := map[string]string{key: string(v)}
+		if strings.EqualFold(key, "failpoints") {
+			fpMap, err = parseFailpoints(string(v))
+			if err != nil {
+				http.Error(w, fmt.Sprintf("fail to parse failpoint: %v", err), http.StatusBadRequest)
+				return
+			}
 		}
-		w.WriteHeader(http.StatusNoContent)
-		if f, ok := w.(http.Flusher); ok {
-			// flush before unlocking so a panic failpoint won't
-			// take down the http server before it sends the response
-			f.Flush()
+
+		for k, v := range fpMap {
+			if err := enable(k, v); err != nil {
+				http.Error(w, fmt.Sprintf("fail to set failpoint: %v", err), http.StatusBadRequest)
+				return
+			}
 		}
-		UnLock()
+		writeCodeAndFlush(w, http.StatusNoContent)
 
 	// gets status of the failpoint
 	case r.Method == "GET":
 		if len(key) == 0 {
-			fps := List()
+			fps := list()
 			sort.Strings(fps)
 			lines := make([]string, len(fps))
 			for i := range lines {
-				s, _ := Status(fps[i])
+				s, _ := status(fps[i])
 				lines[i] = fps[i] + "=" + s
 			}
-			w.Write([]byte(strings.Join(lines, "\n") + "\n"))
+			writeDataAndFlush(w, []byte(strings.Join(lines, "\n")+"\n"))
 		} else {
-			status, err := Status(key)
+			status, err := status(key)
 			if err != nil {
 				http.Error(w, "failed to GET: "+err.Error(), http.StatusNotFound)
 			}
-			w.Write([]byte(status + "\n"))
+			writeDataAndFlush(w, []byte(status+"\n"))
 		}
 
 	// deactivates a failpoint
 	case r.Method == "DELETE":
-		if err := Disable(key); err != nil {
+		if err := disable(key); err != nil {
 			http.Error(w, "failed to delete failpoint "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		w.WriteHeader(http.StatusNoContent)
+		writeCodeAndFlush(w, http.StatusNoContent)
 	default:
 		w.Header().Add("Allow", "DELETE")
 		w.Header().Add("Allow", "GET")
 		w.Header().Set("Allow", "PUT")
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func writeCodeAndFlush(w http.ResponseWriter, statusCode int) {
+	w.WriteHeader(http.StatusNoContent)
+	flush(w)
+}
+
+func writeDataAndFlush(w http.ResponseWriter, data []byte) {
+	w.Write(data)
+	flush(w)
+}
+
+func flush(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		// flush before unlocking so a panic failpoint won't
+		// take down the http server before it sends the response
+		f.Flush()
 	}
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -35,7 +35,8 @@ func init() {
 	envTerms = make(map[string]string)
 	if s := os.Getenv("GOFAIL_FAILPOINTS"); len(s) > 0 {
 		if fpMap, err := parseFailpoints(s); err != nil {
-			panic(err)
+			fmt.Printf("fail to parse failpoint: %v\n", err)
+			os.Exit(1)
 		} else {
 			envTerms = fpMap
 		}
@@ -51,6 +52,9 @@ func init() {
 func parseFailpoints(fps string) (map[string]string, error) {
 	// The format is <FAILPOINT>=<TERMS>[;<FAILPOINT>=<TERMS>]*
 	fpMap := map[string]string{}
+	if len(fps) == 0 {
+		return fpMap, nil
+	}
 	for _, fp := range strings.Split(fps, ";") {
 		fpTerm := strings.Split(fp, "=")
 		if len(fpTerm) != 2 {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFailpoints(t *testing.T) {
+	testCases := []struct {
+		name           string
+		fps            string
+		expectedFpsMap map[string]string
+	}{
+		{
+			name:           "only one valid failpoint",
+			fps:            "failpoint1=print",
+			expectedFpsMap: map[string]string{"failpoint1": "print"},
+		},
+		{
+			name:           "only one invalid failpoint",
+			fps:            "failpoint1",
+			expectedFpsMap: nil,
+		},
+		{
+			name:           "multiple valid failpoints",
+			fps:            "failpoint1=print;failpoint2=sleep(10)",
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "multiple invalid failpoints",
+			fps:            "failpoint1=print_failpoint2=sleep(10)",
+			expectedFpsMap: nil,
+		},
+		{
+			name:           "partial valid failpoints",
+			fps:            "failpoint1=print;failpoint2",
+			expectedFpsMap: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fpsMap, err := parseFailpoints(tc.fps)
+
+			// When tc.expectedFpsMap is nil, then we expect `parseFailpoints` returns error.
+			require.Equal(t, tc.expectedFpsMap == nil, err != nil, "Unexpected result, tc.expectedFpsMap: %v, err: %v", tc.expectedFpsMap, err)
+
+			require.Equal(t, tc.expectedFpsMap, fpsMap, "Unexpected result, expected: %v, got: %v", tc.expectedFpsMap, fpsMap)
+		})
+	}
+}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -23,32 +23,44 @@ func TestParseFailpoints(t *testing.T) {
 	testCases := []struct {
 		name           string
 		fps            string
+		expectErr      bool
 		expectedFpsMap map[string]string
 	}{
 		{
 			name:           "only one valid failpoint",
 			fps:            "failpoint1=print",
+			expectErr:      false,
 			expectedFpsMap: map[string]string{"failpoint1": "print"},
 		},
 		{
 			name:           "only one invalid failpoint",
 			fps:            "failpoint1",
+			expectErr:      true,
 			expectedFpsMap: nil,
 		},
 		{
 			name:           "multiple valid failpoints",
 			fps:            "failpoint1=print;failpoint2=sleep(10)",
+			expectErr:      false,
 			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
 		},
 		{
 			name:           "multiple invalid failpoints",
 			fps:            "failpoint1=print_failpoint2=sleep(10)",
+			expectErr:      true,
 			expectedFpsMap: nil,
 		},
 		{
 			name:           "partial valid failpoints",
 			fps:            "failpoint1=print;failpoint2",
+			expectErr:      true,
 			expectedFpsMap: nil,
+		},
+		{
+			name:           "empty failpoints",
+			fps:            "",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{},
 		},
 	}
 
@@ -57,8 +69,7 @@ func TestParseFailpoints(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fpsMap, err := parseFailpoints(tc.fps)
 
-			// When tc.expectedFpsMap is nil, then we expect `parseFailpoints` returns error.
-			require.Equal(t, tc.expectedFpsMap == nil, err != nil, "Unexpected result, tc.expectedFpsMap: %v, err: %v", tc.expectedFpsMap, err)
+			require.Equal(t, tc.expectErr, err != nil, "Unexpected result, tc.expectErr: %t, err: %v", tc.expectedFpsMap, err)
 
 			require.Equal(t, tc.expectedFpsMap, fpsMap, "Unexpected result, expected: %v, got: %v", tc.expectedFpsMap, fpsMap)
 		})


### PR DESCRIPTION
Users can dynamically setting multiple failpoints using endpoint `/failpoints`, see example below,
```
$ curl http://127.0.0.1:22381/failpoints -X PUT -d'failpoint1=return("hello");failpoint2=sleep(10)'
```

Please review this PR commit by commit.

@spzala @serathius @ramil600 