### PR TITLE
skip empty failpoints in parseFailpoints

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -52,10 +52,11 @@ func init() {
 func parseFailpoints(fps string) (map[string]string, error) {
 	// The format is <FAILPOINT>=<TERMS>[;<FAILPOINT>=<TERMS>]*
 	fpMap := map[string]string{}
-	if len(fps) == 0 {
-		return fpMap, nil
-	}
+
 	for _, fp := range strings.Split(fps, ";") {
+		if len(fp) == 0 {
+			continue
+		}
 		fpTerm := strings.Split(fp, "=")
 		if len(fpTerm) != 2 {
 			err := fmt.Errorf("bad failpoint %q", fp)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -62,6 +62,48 @@ func TestParseFailpoints(t *testing.T) {
 			expectErr:      false,
 			expectedFpsMap: map[string]string{},
 		},
+		{
+			name:           "one empty failpoint at the head",
+			fps:            ";failpoint1=print;failpoint2=sleep(10)",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "multiple empty failpoints at the head",
+			fps:            ";;failpoint1=print;failpoint2=sleep(10)",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "one empty failpoint at the tail",
+			fps:            "failpoint1=print;failpoint2=sleep(10);",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "multiple empty failpoints at the tail",
+			fps:            "failpoint1=print;failpoint2=sleep(10);;",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "one empty failpoint in the middle",
+			fps:            "failpoint1=print;;failpoint2=sleep(10)",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "multiple empty failpoints in the middle",
+			fps:            "failpoint1=print;;;failpoint2=sleep(10)",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
+		{
+			name:           "multiple empty failpoints at different places",
+			fps:            ";failpoint1=print;;failpoint2=sleep(10);",
+			expectErr:      false,
+			expectedFpsMap: map[string]string{"failpoint1": "print", "failpoint2": "sleep(10)"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Please see examples in the newly added unit test cases.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala @ptabor 