### PR TITLE
Bump go to supported 1.19 release

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,4 @@
+---
 name: golangci-lint
 on:
   push:
@@ -18,13 +19,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.53
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+---
 name: tests
 on:
   push:
@@ -18,9 +19,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: tests
         run: |
           make test
-

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
+---
 run:
-  go: '1.17'
   timeout: 30m
   skip-files:
     - "^zz_generated.*"

--- a/code/binding_test.go
+++ b/code/binding_test.go
@@ -17,7 +17,7 @@ package code
 import (
 	"bytes"
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/gofail
 
-go 1.17
+go 1.19
 
 require github.com/stretchr/testify v1.8.1
 

--- a/runtime/failpoint_test.go
+++ b/runtime/failpoint_test.go
@@ -16,7 +16,7 @@ package runtime
 
 import (
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This pull request proposes to align gofail with go versions used by other etcd-io subprojects as Go `1.17` is out of support. This brings gofail in line with other etcd-io maintained projects and addresses CVEs with older versions of golang.

Additionally this pr also:
 - bumps the version of `golangci-lint` we are running to latest upstream minor release.
 - removes go version from `.golangci.yaml` configuration so the default of go.mod version will be used.
 - fixes some minor issues reported by `yamllint`.