### PR TITLE
Add minimal verify and fix makefile gofmt targets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: tests
         run: |
+          make verify
           make test

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,22 @@ all: gofail
 clean:
 	rm -f gofail
 
+verify: verify-gofmt
+
+.PHONY: verify-gofmt
+verify-gofmt:
+	@echo "Verifying gofmt, failures can be fixed with 'make fix'"
+	@!(gofmt -l -s -d . | grep '[a-z]')
+
 .PHONY: test
 test:
 	go test -v --race -cpu=1,2,4 ./code/ ./runtime/
 
-.PHONY: fmt
-fmt:
-	gofmt -w -l -s $(SRCS)
+fix: fix-gofmt
+
+.PHONY: fix-gofmt
+fix-gofmt:
+	gofmt -w .
 
 gofail: 
 	GO_BUILD_FLAGS="-v" ./build.sh


### PR DESCRIPTION
This pull request will ensure future changes to `etcd-io/gofail` will have `gofmt` static analysis run as part of automated test workflows.

Additionally a helper `make fix` target has been introduced to provide a quick way for automated fixes to be applied.

This will reduce the burden on reviewers to manually identify these issues, for example in https://github.com/etcd-io/gofail/pull/49.