### PR TITLE
Update to golang 1.20 minor release

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.8
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.8
       - uses: actions/checkout@v4
       - name: tests
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/gofail
 
-go 1.19
+go 1.20
 
 require github.com/stretchr/testify v1.8.4
 


### PR DESCRIPTION
Quick maintenance to keep gofail in line with `etcd-io/etcd` and using a supported go version.