### PR TITLE
Upgrade go to latest patch release and improve linting standards

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.8
+          go-version: 1.20.10
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.8
+          go-version: 1.20.10
       - uses: actions/checkout@v4
       - name: tests
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,7 +35,6 @@ linters-settings: # please keep this alphabetized
   staticcheck:
     checks:
       - "all"
-      - "-SA1019" # TODO(fix) Using a deprecated function, variable, constant or field
       - "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
   stylecheck:
     checks:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,8 @@ linters:
     - revive
     - staticcheck
     - stylecheck
+    - unconvert
+    - unparam
     - unused
 
 linters-settings: # please keep this alphabetized

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,7 @@ linters:
     - goimports
     - ineffassign
     - nakedret
+    - revive
     - staticcheck
     - stylecheck
     - unused

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,9 @@ linters:
   # - deadcode
   # - structcheck
   # - varcheck
+    - goimports
     - ineffassign
+    - nakedret
     - staticcheck
     - stylecheck
     - unused

--- a/code/rewrite.go
+++ b/code/rewrite.go
@@ -55,11 +55,10 @@ func ToFailpoints(wdst io.Writer, rsrc io.Reader) ([]*Failpoint, error) {
 				}
 				curfp.code = append(curfp.code, strings.Replace(l, "//", "\t", 1))
 				continue
-			} else {
-				curfp.flush(dst)
-				fps = append(fps, curfp)
-				curfp = nil
 			}
+			curfp.flush(dst)
+			fps = append(fps, curfp)
+			curfp = nil
 		} else if label := gofailLabel(l, pfxGofail, labelGofail); label != "" {
 			// expose gofail label
 			l = label

--- a/code/rewrite.go
+++ b/code/rewrite.go
@@ -30,8 +30,10 @@ const (
 
 // ToFailpoints turns all gofail comments into failpoint code. Returns a list of
 // all failpoints it activated.
-func ToFailpoints(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
+func ToFailpoints(wdst io.Writer, rsrc io.Reader) ([]*Failpoint, error) {
+	var err error
 	var curfp *Failpoint
+	var fps []*Failpoint
 
 	dst := bufio.NewWriter(wdst)
 	defer func() {
@@ -62,24 +64,27 @@ func ToFailpoints(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) 
 			// expose gofail label
 			l = label
 		} else if curfp, err = newFailpoint(l); err != nil {
-			return
+			return nil, err
 		} else if curfp != nil {
 			// found a new failpoint
 			continue
 		}
 		if _, err = dst.WriteString(l); err != nil {
-			return
+			return nil, err
 		}
 		if rerr == io.EOF {
 			break
 		}
 	}
-	return
+	return fps, err
 }
 
 // ToComments turns all failpoint code into GOFAIL comments. It returns
 // a list of all failpoints  it deactivated.
-func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
+func ToComments(wdst io.Writer, rsrc io.Reader) ([]*Failpoint, error) {
+	var err error
+	var fps []*Failpoint
+
 	src := bufio.NewReader(rsrc)
 	dst := bufio.NewWriter(wdst)
 	ws := ""
@@ -130,7 +135,7 @@ func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
 		err = nil
 	}
 	dst.Flush()
-	return
+	return fps, err
 }
 
 func gofailLabel(l string, pfx string, lb string) string {

--- a/runtime/failpoint.go
+++ b/runtime/failpoint.go
@@ -35,11 +35,11 @@ func (fp *Failpoint) Acquire() (interface{}, error) {
 	if fp.t == nil {
 		return nil, ErrDisabled
 	}
-	v, err := fp.t.eval()
-	if v == nil {
-		err = ErrDisabled
+	result := fp.t.eval()
+	if result == nil {
+		return nil, ErrDisabled
 	}
-	return v, err
+	return result, nil
 }
 
 // BadType is called when the failpoint evaluates to the wrong type.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -34,12 +34,12 @@ func init() {
 	failpoints = make(map[string]*Failpoint)
 	envTerms = make(map[string]string)
 	if s := os.Getenv("GOFAIL_FAILPOINTS"); len(s) > 0 {
-		if fpMap, err := parseFailpoints(s); err != nil {
+		fpMap, err := parseFailpoints(s)
+		if err != nil {
 			fmt.Printf("fail to parse failpoint: %v\n", err)
 			os.Exit(1)
-		} else {
-			envTerms = fpMap
 		}
+		envTerms = fpMap
 	}
 	if s := os.Getenv("GOFAIL_HTTP"); len(s) > 0 {
 		if err := serve(s); err != nil {

--- a/runtime/terms.go
+++ b/runtime/terms.go
@@ -289,7 +289,7 @@ var actMap = map[string]actFunc{
 
 func (t *term) do() interface{} { return t.act(t) }
 
-func actOff(t *term) interface{} { return nil }
+func actOff(_ *term) interface{} { return nil }
 
 func actReturn(t *term) interface{} { return t.val }
 
@@ -320,7 +320,7 @@ func actPanic(t *term) interface{} {
 	panic("failpoint panic: " + t.parent.fpath)
 }
 
-func actBreak(t *term) interface{} {
+func actBreak(_ *term) interface{} {
 	p, perr := exec.LookPath(os.Args[0])
 	if perr != nil {
 		panic(perr)

--- a/runtime/terms.go
+++ b/runtime/terms.go
@@ -97,15 +97,15 @@ func newTerms(fpath, desc string) (*terms, error) {
 
 func (t *terms) String() string { return t.desc }
 
-func (t *terms) eval() (interface{}, error) {
+func (t *terms) eval() interface{} {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, term := range t.chain {
 		if term.mods.allow() {
-			return term.do(), nil
+			return term.do()
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 // split terms from a -> b -> ... into [a, b, ...]

--- a/runtime/terms_test.go
+++ b/runtime/terms_test.go
@@ -35,12 +35,9 @@ func TestTermsString(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, w := range tt.weval {
-			v, eerr := ter.eval()
+			v := ter.eval()
 			if v == nil && w == "" {
 				continue
-			}
-			if eerr != nil {
-				t.Fatal(err)
 			}
 			if v.(string) != w {
 				t.Fatalf("got %q, expected %q", v, w)
@@ -65,7 +62,7 @@ func TestTermsTypes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		v, _ := ter.eval()
+		v := ter.eval()
 		if v == nil && tt.weval == nil {
 			continue
 		}


### PR DESCRIPTION
Recently in `etcd-io/etcd` @fuweid significantly improved our codebase linting.

This pull request proposes we enable a similar code quality standard for `etcd-io/gofail` and also updates go to the latest patch release `1.20.10`.