### PR TITLE
Fix execution of failpoint should not block deactivation

### DIFF
--- a/runtime/http.go
+++ b/runtime/http.go
@@ -37,14 +37,11 @@ func serve(host string) error {
 }
 
 func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// This prevents all failpoints from being triggered. It ensures
-	// the server(runtime) doesn't panic due to any failpoints during
-	// processing the HTTP request.
-	// It may be inefficient, but correctness is more important than
-	// efficiency. Usually users will not enable too many failpoints
-	// at a time, so it (the efficiency) isn't a problem.
-	failpointsMu.Lock()
-	defer failpointsMu.Unlock()
+	// Ensures the server(runtime) doesn't panic due to the execution of
+	// panic failpoints during processing of the HTTP request
+	panicMu.Lock()
+	defer panicMu.Unlock()
+
 	// flush before unlocking so a panic failpoint won't
 	// take down the http server before it sends the response
 	defer flush(w)

--- a/runtime/http.go
+++ b/runtime/http.go
@@ -72,7 +72,7 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for k, v := range fpMap {
-			if err := enable(k, v); err != nil {
+			if err := Enable(k, v); err != nil {
 				http.Error(w, fmt.Sprintf("fail to set failpoint: %v", err), http.StatusBadRequest)
 				return
 			}
@@ -86,13 +86,13 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			sort.Strings(fps)
 			lines := make([]string, len(fps))
 			for i := range lines {
-				s, _, _ := status(fps[i])
+				s, _, _ := Status(fps[i])
 				lines[i] = fps[i] + "=" + s
 			}
 			w.Write([]byte(strings.Join(lines, "\n") + "\n"))
 		} else if strings.HasSuffix(key, "/count") {
 			fp := key[:len(key)-len("/count")]
-			_, count, err := status(fp)
+			_, count, err := Status(fp)
 			if err != nil {
 				if errors.Is(err, ErrNoExist) {
 					http.Error(w, "failed to GET: "+err.Error(), http.StatusNotFound)
@@ -103,7 +103,7 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			w.Write([]byte(strconv.Itoa(count)))
 		} else {
-			status, _, err := status(key)
+			status, _, err := Status(key)
 			if err != nil {
 				http.Error(w, "failed to GET: "+err.Error(), http.StatusNotFound)
 			}
@@ -112,7 +112,7 @@ func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// deactivates a failpoint
 	case r.Method == "DELETE":
-		if err := disable(key); err != nil {
+		if err := Disable(key); err != nil {
 			http.Error(w, "failed to delete failpoint "+err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/runtime/http.go
+++ b/runtime/http.go
@@ -38,7 +38,9 @@ func serve(host string) error {
 
 func (*httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Ensures the server(runtime) doesn't panic due to the execution of
-	// panic failpoints during processing of the HTTP request
+	// panic failpoints during processing of the HTTP request, as the
+	// sender of the HTTP request should not be affected by the execution
+	// of the panic failpoints and crash as a side effect
 	panicMu.Lock()
 	defer panicMu.Unlock()
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -27,7 +27,10 @@ var (
 
 	failpoints   map[string]*Failpoint
 	failpointsMu sync.RWMutex
-	envTerms     map[string]string
+
+	envTerms map[string]string
+
+	panicMu sync.Mutex
 )
 
 func init() {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -72,11 +72,6 @@ func parseFailpoints(fps string) (map[string]string, error) {
 
 // Enable sets a failpoint to a given failpoint description.
 func Enable(name, inTerms string) error {
-	return enable(name, inTerms)
-}
-
-// enable enables a failpoint
-func enable(name, inTerms string) error {
 	failpointsMu.RLock()
 	fp := failpoints[name]
 	failpointsMu.RUnlock()
@@ -100,10 +95,6 @@ func enable(name, inTerms string) error {
 
 // Disable stops a failpoint from firing.
 func Disable(name string) error {
-	return disable(name)
-}
-
-func disable(name string) error {
 	failpointsMu.RLock()
 	fp := failpoints[name]
 	failpointsMu.RUnlock()
@@ -124,10 +115,6 @@ func disable(name string) error {
 
 // Status gives the current setting and execution count for the failpoint
 func Status(failpath string) (string, int, error) {
-	return status(failpath)
-}
-
-func status(failpath string) (string, int, error) {
 	failpointsMu.RLock()
 	fp := failpoints[failpath]
 	failpointsMu.RUnlock()
@@ -171,7 +158,7 @@ func register(name string) *Failpoint {
 	failpoints[name] = fp
 	failpointsMu.Unlock()
 	if t, ok := envTerms[name]; ok {
-		enable(name, t)
+		Enable(name, t)
 	}
 	return fp
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -86,6 +86,10 @@ func enable(name, inTerms string) error {
 		fmt.Printf("failed to enable \"%s=%s\" (%v)\n", name, inTerms, err)
 		return err
 	}
+
+	fp.failpointMu.Lock()
+	defer fp.failpointMu.Unlock()
+
 	fp.t = t
 
 	return nil
@@ -104,6 +108,9 @@ func disable(name string) error {
 		return ErrNoExist
 	}
 
+	fp.failpointMu.Lock()
+	defer fp.failpointMu.Unlock()
+
 	if fp.t == nil {
 		return ErrDisabled
 	}
@@ -116,6 +123,7 @@ func disable(name string) error {
 func Status(failpath string) (string, int, error) {
 	failpointsMu.Lock()
 	defer failpointsMu.Unlock()
+
 	return status(failpath)
 }
 
@@ -124,6 +132,9 @@ func status(failpath string) (string, int, error) {
 	if fp == nil {
 		return "", 0, ErrNoExist
 	}
+
+	fp.failpointMu.RLock()
+	defer fp.failpointMu.RUnlock()
 
 	t := fp.t
 	if t == nil {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -25,11 +25,17 @@ var (
 	ErrNoExist  = fmt.Errorf("failpoint: failpoint does not exist")
 	ErrDisabled = fmt.Errorf("failpoint: failpoint is disabled")
 
-	failpoints   map[string]*Failpoint
+	failpoints map[string]*Failpoint
+	// failpointsMu protects the failpoints map, preventing concurrent
+	// accesses during commands such as Enabling and Disabling
 	failpointsMu sync.RWMutex
 
 	envTerms map[string]string
 
+	// panicMu (panic mutex) ensures that the action of panic failpoints
+	// and serving of the HTTP requests won't be executed at the same time,
+	// avoiding the possibility that the server runtime panics during processing
+	// requests
 	panicMu sync.Mutex
 )
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -85,10 +85,7 @@ func Enable(name, inTerms string) error {
 		return err
 	}
 
-	fp.failpointMu.Lock()
-	defer fp.failpointMu.Unlock()
-
-	fp.t = t
+	fp.SetTerm(t)
 
 	return nil
 }
@@ -102,15 +99,7 @@ func Disable(name string) error {
 		return ErrNoExist
 	}
 
-	fp.failpointMu.Lock()
-	defer fp.failpointMu.Unlock()
-
-	if fp.t == nil {
-		return ErrDisabled
-	}
-	fp.t = nil
-
-	return nil
+	return fp.ClearTerm()
 }
 
 // Status gives the current setting and execution count for the failpoint
@@ -122,15 +111,7 @@ func Status(failpath string) (string, int, error) {
 		return "", 0, ErrNoExist
 	}
 
-	fp.failpointMu.RLock()
-	defer fp.failpointMu.RUnlock()
-
-	t := fp.t
-	if t == nil {
-		return "", 0, ErrDisabled
-	}
-
-	return t.desc, t.counter, nil
+	return fp.Status()
 }
 
 func List() []string {

--- a/runtime/terms.go
+++ b/runtime/terms.go
@@ -317,6 +317,9 @@ func actSleep(t *term) interface{} {
 }
 
 func actPanic(t *term) interface{} {
+	panicMu.Lock()
+	defer panicMu.Unlock()
+
 	if t.val != nil {
 		panic(fmt.Sprintf("failpoint panic: %v", t.val))
 	}


### PR DESCRIPTION
There are 2 main flows of the gofail library: namely, enable/disable and execution (`Acquire`) of the failpoints.

Currently, a mutex is protecting both flows, thus, only one action can make progress at a time.

This PR proposes a fine-grained mutex, as each failpoint is protected under a dedicated `RWMutex`. The existing `failpointsMu` will only be protecting the main shared data structures, such as the `failpoints` map.

Notice that in our current implementation, the execution of the same failpoint is still sequential (there is a lock within `eval` on the term being executed)

Reference:
- https://github.com/etcd-io/gofail/issues/64