### PR TITLE
gofail: update golang toolchain to 1.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/gofail
 
 go 1.22
 
-toolchain go1.22.10
+toolchain go1.22.11
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
Updates gofail golang toolchain from 1.22.10 to 1.22.11

Subtask from Issue: https://github.com/etcd-io/etcd/issues/19210

Verified as:

```
make all && make test
```