### PR TITLE
Updates golang toolchain to version 1.22.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/gofail
 
 go 1.22
 
-toolchain go1.22.11
+toolchain go1.22.12
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
Updating golang toolchain to version 1.22.12

Subtask from https://github.com/etcd-io/etcd/issues/19333

Verified with

```
make all
make test
```

