### PR TITLE
Add integ test for http server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,22 @@ First, enable the HTTP server from the command line,
 GOFAIL_HTTP="127.0.0.1:1234" ./cmd
 ```
 
-
-Activate a failpoint with curl,
+Activate a single failpoint with curl,
 
 ```sh
 $ curl http://127.0.0.1:1234/SomeFuncString -XPUT -d'return("hello")'
 ```
 
+Activate multiple failpoints atomically with the special `/failpoints` endpoint. The payload is the same as for `GOFAIL_FAILPOINTS` above:
+
+```sh
+$ curl http://127.0.0.1:1234/failpoints -XPUT -d'failpoint1=return("hello");failpoint2=sleep(10)'
+```
+
 List the failpoints,
 
 ```sh
-$ curl http://127.0.0.1:1234/SomeFuncString=return("hello")
+$ curl http://127.0.0.1:1234/SomeFuncString
 ```
 
 Retrieve the execution count of a failpoint,

--- a/examples/cmd/cmd.go
+++ b/examples/cmd/cmd.go
@@ -27,16 +27,18 @@ GOFAIL_HTTP=:22381 go run cmd.go
 curl -L http://localhost:22381
 
 curl \
-  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabels \
+  -L http://localhost:22381/ExampleLabels \
   -X PUT -d'return'
 
 curl \
-  -L http://localhost:22381/github.com/coreos/gofail/examples/ExampleLabels \
+  -L http://localhost:22381/ExampleLabels \
   -X DELETE
 */
 
 func main() {
 	for {
+		log.Println(examples.ExampleFunc())
+		log.Println(examples.ExampleOneLineFunc())
 		log.Println(examples.ExampleLabelsFunc())
 		time.Sleep(time.Second)
 	}

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,5 +1,5 @@
 # Integration Tests
 
 Each directory contains a scenario
-
-- sleep: the enabling and disabling of a failpoint won't be delayed due to an ongoing sleep() action
+* sleep: the enabling and disabling of a failpoint won't be delayed due to an ongoing sleep() action
+* server: exercises the HTTP failpoint control API and checks basic functionality

--- a/integration/makefile.mk
+++ b/integration/makefile.mk
@@ -8,6 +8,7 @@ run-all-integration-tests:
 	# we compile and execute all integration tests
 	# add new integration test targets here
 	$(MAKE) run-integration-test-sleep 
+	$(MAKE) run-integration-test-server
 
 	# we disable all failpoints
 	$(MAKE) gofail-disable
@@ -19,10 +20,17 @@ clean-all-integration-tests: clean-integration-test-sleep gofail-disable
 .PHONY: gofail-enable
 gofail-enable: build-gofail
 	$(GOFAIL_BINARY) enable ./integration/sleep/failpoints
+	$(GOFAIL_BINARY) enable ./integration/server/failpoints
 
 .PHONY: gofail-disable
 gofail-disable: build-gofail
-	${GOFAIL_BINARY} disable ./integration/sleep/failpoints
+	$(GOFAIL_BINARY) disable ./integration/sleep/failpoints
+	$(GOFAIL_BINARY) disable ./integration/server/failpoints
+
+# run integration test - server
+.PHONY: run-integration-test-server
+run-integration-test-server:
+	cd ./integration/server && go test -v .
 
 # run integration test - sleep
 .PHONY: run-integration-test-sleep

--- a/integration/server/failpoints/failpoints.go
+++ b/integration/server/failpoints/failpoints.go
@@ -1,0 +1,28 @@
+package failpoints
+
+func ExampleFunc() string {
+	// gofail: var ExampleString string
+	// return ExampleString
+	return "example"
+}
+
+func ExampleOneLineFunc() string {
+	// gofail: var ExampleOneLine struct{}
+	return "abc"
+}
+
+func ExampleLabelsFunc() string {
+	i := 0
+	s := ""
+	// gofail: myLabel:
+	for i < 5 {
+		s = s + "i"
+		i++
+		for j := 0; j < 5; j++ {
+			s = s + "j"
+			// gofail: var ExampleLabels struct{}
+			// continue myLabel
+		}
+	}
+	return s
+}

--- a/integration/server/go.mod
+++ b/integration/server/go.mod
@@ -1,0 +1,16 @@
+module go.etcd.io/gofail/integration/server
+
+go 1.22
+
+toolchain go1.22.10
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.etcd.io/gofail v0.1.1-0.20240328162059-93c579a86c46 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace go.etcd.io/gofail => ./../../

--- a/integration/server/go.sum
+++ b/integration/server/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.etcd.io/gofail v0.1.1-0.20240328162059-93c579a86c46 h1:q2duvcm+tRj5lNb5RcDQ6QTs6n9Ou0L0p/74jEJwQaE=
+go.etcd.io/gofail v0.1.1-0.20240328162059-93c579a86c46/go.mod h1:UD5kxjMWxJacjLWHSqGM3zn4a9ItpE06Eg7ttpm0Lhs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/integration/server/main.go
+++ b/integration/server/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go.etcd.io/gofail/integration/server/failpoints"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+)
+
+var funcMap = map[string]interface{}{
+	"ExampleFunc":        failpoints.ExampleFunc,
+	"ExampleOneLineFunc": failpoints.ExampleOneLineFunc,
+	"ExampleLabelsFunc":  failpoints.ExampleLabelsFunc,
+}
+
+func callFuncByName(name string, args []string) (interface{}, error) {
+	fn, exists := funcMap[name]
+	if !exists {
+		return nil, fmt.Errorf("function %s does not exist", name)
+	}
+
+	fnValue := reflect.ValueOf(fn)
+	expectedNArgs := fnValue.Type().NumIn()
+	gotNArgs := len(args)
+	if expectedNArgs != gotNArgs {
+		return nil, fmt.Errorf("wrong number of arguments for function %s. "+
+			"Expected %d, got %d", name, expectedNArgs, gotNArgs)
+	}
+
+	in := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		in[i] = reflect.ValueOf(arg)
+	}
+
+	result := fnValue.Call(in)
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result[0].Interface(), nil
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("received request: %v", r)
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "invalid URL path", http.StatusBadRequest)
+		return
+	}
+	funcName := pathParts[2]
+	args := r.URL.Query()["args"]
+
+	result, err := callFuncByName(funcName, args)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	response, err := json.Marshal(result)
+	if err != nil {
+		http.Error(w, "failed to marshal response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(response)
+	if err != nil {
+		http.Error(w, "failed to write response", http.StatusInternalServerError)
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("Port number is required as a command line argument")
+	}
+	port := os.Args[1]
+
+	http.HandleFunc("/call/", handler)
+	log.Printf("Starting server on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/integration/server/server_test.go
+++ b/integration/server/server_test.go
@@ -1,0 +1,700 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// portAssignments is a struct that holds the ports for the gofail and server servers
+type portAssignments struct {
+	// gofailPort is the port the gofail failpoint control API is running on
+	gofailPort int
+
+	// serverPort is the port the server test status API is running on
+	serverPort int
+}
+
+func getOpenPorts(count int) ([]int, error) {
+	ports := make([]int, 0, count)
+	for i := 0; i < count; i++ {
+		listener, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			return nil, err
+		}
+
+		// We want to keep listeners open until loop finishes so we don't accidentally reuse a port.
+		defer listener.Close()
+
+		addr := listener.Addr().(*net.TCPAddr)
+		ports = append(ports, addr.Port)
+	}
+	return ports, nil
+}
+
+type testRequest interface {
+	// AssertResponse is the heart of the test logic. It sends the request to the server,
+	// then checks the response matches expectations.
+	AssertResponse(t *testing.T)
+	// SetupPortAssignments is a helper for setting correct request.port value
+	SetupPortAssignments(ports portAssignments)
+}
+
+type response struct {
+	statusCode int
+	body       string
+}
+
+type request struct {
+	port       int
+	methodType string
+	endpoint   string
+	args       []string
+	expected   response
+}
+
+// serverTestRequest is a test request for the server test status API
+type serverTestRequest struct {
+	request
+}
+
+func (s *serverTestRequest) AssertResponse(t *testing.T) {
+	t.Helper()
+
+	// See main.go for endpoint definitions
+	endpoint := "call/" + s.endpoint
+	if len(s.args) > 0 {
+		// http server interprets "?args=" as having a single argument of value ""
+		endpoint += "?args=" + strings.Join(s.args, ",")
+	}
+
+	methodType := http.MethodGet
+	if s.methodType != "" {
+		methodType = s.methodType
+	}
+	body, statusCode, err := sendRequest(t, s.port, methodType, endpoint, []byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, s.expected.statusCode, statusCode)
+	assert.Equal(t, s.expected.body, body)
+}
+
+func (s *serverTestRequest) SetupPortAssignments(ports portAssignments) {
+	s.port = ports.serverPort
+}
+
+// gofailTestRequest is a test request for the gofail server control API
+type gofailTestRequest struct {
+	request
+
+	// requestType is the kind of request we're making to the failpoint control API.
+	// These correspond to the operations described in the "HTTP endpoint" section of the README.
+	//
+	// Valid values are put, failpoints, listall, list, count, deactivate
+	// * put: sets the value of a failpoint, enabling it
+	// * failpoints: sets the values of multiple failpoints at once
+	// * listall: lists all failpoints and their values
+	// * list: lists the value of a single failpoint
+	// * count: gets the number of times a failpoint has been hit
+	// * deactivate: clears a given failpoint
+	requestType string
+}
+
+func (g *gofailTestRequest) AssertResponse(t *testing.T) {
+	t.Helper()
+	require.NotEqual(t, g.port, 0, "port is not set")
+
+	endpoint := g.endpoint
+	payload := ""
+	var methodType string
+
+	switch g.requestType {
+	case "put":
+		methodType = http.MethodPut
+		assert.NotEmpty(t, g.endpoint, "endpoint should not be empty for `put' request type")
+		assert.Equalf(t, len(g.args), 1, "args should have exactly one element for `put' request type")
+		payload = g.args[0]
+		break
+	case "failpoints":
+		methodType = http.MethodPut
+		assert.Equalf(t, g.endpoint, "", "endpoint should be empty for `failpoints' request type")
+		endpoint = "failpoints"
+		payload = strings.Join(g.args, ";")
+		break
+	case "listall":
+		methodType = http.MethodGet
+		assert.Equalf(t, g.endpoint, "", "endpoint should be empty for `listall' request type")
+		assert.Nil(t, g.args, "args should be nil for `listall' request type")
+		endpoint = ""
+		break
+	case "list":
+		methodType = http.MethodGet
+		assert.NotEmpty(t, g.endpoint, "endpoint should not be empty for `list' request type")
+		assert.Nil(t, g.args, "args should be nil for `list' request type")
+		break
+	case "count":
+		methodType = http.MethodGet
+		assert.NotEmpty(t, g.endpoint, "endpoint should not be empty for `count' request type")
+		assert.Nil(t, g.args, "args should be nil for `count' request type")
+		endpoint += "/count"
+	case "deactivate":
+		methodType = http.MethodDelete
+		assert.NotEmpty(t, g.endpoint, "endpoint should not be empty for `delete' request type")
+		assert.Nil(t, g.args, "args should be nil for `deactivate' request type")
+	default:
+		t.Errorf("unknown request type: %s", g.requestType)
+		return
+	}
+
+	body, statusCode, err := sendRequest(t, g.port, methodType, endpoint, []byte(payload))
+	assert.NoError(t, err)
+	assert.Equal(t, g.expected.statusCode, statusCode)
+
+	if g.requestType != "listall" {
+		assert.Equal(t, g.expected.body, body)
+	} else {
+		// listall responses don't guarantee an order, so we need a more sophisticated test.
+
+		// This is a pretty naive way to convert strings to maps, and will break
+		// if any of the keys/values contain the separator characters.
+		stringToMap := func(s, entrySep, kvSep string) map[string]string {
+			result := make(map[string]string)
+			entries := strings.Split(s, entrySep)
+			for _, entry := range entries {
+				kv := strings.SplitN(entry, kvSep, 2)
+				if len(kv) == 2 {
+					result[kv[0]] = kv[1]
+				}
+			}
+			return result
+		}
+
+		expected := stringToMap(g.expected.body, "\n", "=")
+		actual := stringToMap(body, "\n", "=")
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf(
+				"listall response did not match:\n\tExpected:\t%#v\n\tActual:\t\t%#v",
+				expected, actual)
+		}
+	}
+}
+
+func (g *gofailTestRequest) SetupPortAssignments(ports portAssignments) {
+	g.port = ports.gofailPort
+}
+
+// sendRequest is the core helper method
+func sendRequest(t *testing.T, port int, method string, endpoint string, data []byte) (string, int, error) {
+	t.Helper()
+
+	url := fmt.Sprintf("http://localhost:%d/%s", port, endpoint)
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(data))
+	if err != nil {
+		return "", 0, err
+	}
+
+	t.Logf("Sending request: %s %s %s", method, url, data)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer assert.NoError(t, req.Body.Close())
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return string(body), resp.StatusCode, nil
+}
+
+// request generation helpers
+
+func rgListAllSuccess(expected string) testRequest {
+	return &gofailTestRequest{
+		requestType: "listall",
+		request: request{
+			expected: response{
+				statusCode: 200,
+				body:       expected,
+			},
+		},
+	}
+}
+
+func rgCountSuccess(endpoint string, expected int) testRequest {
+	return &gofailTestRequest{
+		requestType: "count",
+		request: request{
+			endpoint: endpoint,
+			expected: response{
+				statusCode: 200,
+				body:       fmt.Sprintf("%d", expected),
+			},
+		},
+	}
+}
+
+func rgTestServerSuccess(endpoint string, expected string, args ...string) testRequest {
+	return &serverTestRequest{
+		request: request{
+			endpoint: endpoint,
+			args:     args,
+			expected: response{
+				statusCode: 200,
+				body:       "\"" + expected + "\"",
+			},
+		},
+	}
+}
+
+// TestAll is a comprehensive test suite for the server and gofail control APIs.
+// Each test consists of a series of requests and expected responses to send to either API.
+// The tests share a single server process which preserves state between tests,
+// so they must be run in order.  We could potentially change this to spawn separate
+// server instances per test, which would isolate the test cases, at the cost of making
+// some individual cases more complex.
+//
+// Some notes for maintainers:
+//   - When debugging in an IDE, make sure to run `make gofail-enable` in the root directory
+//     to enable the gofail failpoint control API.
+//   - Make sure to run all tests every time, as later tests depend on earlier ones.
+//     Fortunately, they run very quickly.  If necessary, you can reset state by sending
+//     deactivate requests for the relevant failpoints.
+//   - You can spawn the main.go server manually and attach a debugger to it, then hack
+//     getOpenPorts() to return the relevant ports.  This will allow you to effectively
+//     debug client-server interactions. You may need to increase the timeout variable
+//     below.
+//     That said, stdout/err messages from the server process are emitted in the test
+//     output, and are usually sufficient for debugging.
+func TestAll(t *testing.T) {
+	timeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ports, err := getOpenPorts(2)
+	require.NoError(t, err)
+	pas := portAssignments{gofailPort: ports[0], serverPort: ports[1]}
+
+	waitForServer := make(chan any)
+
+	// Spawn server.go in a goroutine
+	go func() {
+		defer func() {
+			println("Server goroutine exited")
+		}()
+
+		pipeToStdout := func(reader io.ReadCloser) {
+			scanner := bufio.NewScanner(reader)
+			for scanner.Scan() {
+				fmt.Println("[Test Server] " + scanner.Text())
+			}
+		}
+
+		cmd := exec.CommandContext(ctx, "go", "run", "main.go", fmt.Sprintf("%d", pas.serverPort))
+
+		stdoutReader, err := cmd.StdoutPipe()
+		require.NoError(t, err)
+		stderrReader, err := cmd.StderrPipe()
+		require.NoError(t, err)
+		go pipeToStdout(stdoutReader)
+		go pipeToStdout(stderrReader)
+
+		cmd.WaitDelay = timeout
+		cmd.Env = append(os.Environ(), fmt.Sprintf("GOFAIL_HTTP=:%d", pas.gofailPort))
+		t.Logf("Starting server: GOFAIL_HTTP=:%d %v", pas.gofailPort, cmd)
+
+		err = cmd.Start()
+		require.NoError(t, err)
+		t.Logf("Waiting for server to be available, pid %d", cmd.Process.Pid)
+		assert.Eventuallyf(t, func() bool {
+			_, statusCode, _ := sendRequest(t, pas.serverPort, http.MethodGet, "call/ExampleFunc", []byte{})
+			return statusCode == 200
+		}, timeout, 100*time.Millisecond, "Server did not become available in time")
+
+		// signal server start
+		waitForServer <- struct{}{}
+
+		t.Logf("Waiting for server to exit, pid %d", cmd.Process.Pid)
+		err = cmd.Wait()
+
+		// We always stop the server by cancelling the context, so this should always be sigkill
+		t.Logf("Server exited (sigkill is expected) with error: %v, context cancellation reason %v", err, ctx.Err())
+		assert.Error(t, err)
+
+		// signal server exit
+		waitForServer <- struct{}{}
+	}()
+
+	defer func() {
+		// Give it some time to drain IO pipes
+		time.Sleep(1 * time.Second)
+		cancel()
+
+		// Wait for the server to exit
+		<-waitForServer
+	}()
+
+	// Wait for server to start and be ready
+	<-waitForServer
+
+	tests := []struct {
+		name     string
+		requests []testRequest
+	}{
+		{
+			name: "Empty listall",
+			requests: []testRequest{
+				rgListAllSuccess("ExampleLabels=\nExampleOneLine=\nExampleString=\n"),
+			},
+		},
+		{
+			name: "list for disabled failpoint returns 404",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "list",
+					request: request{
+						endpoint: "ExampleString",
+						expected: response{
+							statusCode: 404,
+							body:       "failed to GET: failpoint: failpoint is disabled\n\n",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "list for invalid failpoint returns 404",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "list",
+					request: request{
+						endpoint: "InvalidFailpoint",
+						expected: response{
+							statusCode: 404,
+							body:       "failed to GET: failpoint: failpoint does not exist\n\n",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "count fails for disabled failpoints",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "count",
+					request: request{
+						endpoint: "ExampleLabels",
+						expected: response{
+							statusCode: 500,
+							body:       "failed to GET: failpoint: failpoint is disabled\n",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "count fails for invalid failpoints",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "count",
+					request: request{
+						endpoint: "InvalidFailpoint",
+						expected: response{
+							statusCode: 404,
+							body:       "failed to GET: failpoint: failpoint does not exist\n",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "count starts at 0",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "put",
+					request: request{
+						endpoint: "ExampleString",
+						args:     []string{"return(\"fail string\")"},
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				rgCountSuccess("ExampleString", 0),
+			},
+		},
+		{
+			name: "list works for enabled failpoints",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "list",
+					request: request{
+						endpoint: "ExampleString",
+						expected: response{
+							statusCode: 200,
+							body:       "return(\"fail string\")\n",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "listall after put",
+			requests: []testRequest{
+				rgListAllSuccess("ExampleLabels=\nExampleOneLine=\nExampleString=return(\"fail string\")\n"),
+			},
+		},
+		{
+			name: "count increments to 1",
+			requests: []testRequest{
+				rgTestServerSuccess("ExampleFunc", "fail string"),
+				rgCountSuccess("ExampleString", 1),
+			},
+		},
+		{
+			name: "putting a new value updates an existing failpoint",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "put",
+					request: request{
+						endpoint: "ExampleString",
+						args:     []string{"return(\"new fail string\")"},
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				rgCountSuccess("ExampleString", 0),
+				rgTestServerSuccess("ExampleFunc", "new fail string"),
+				rgCountSuccess("ExampleString", 1),
+			},
+		},
+		{
+			name: "deactivate works",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "deactivate",
+					request: request{
+						endpoint: "ExampleString",
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				rgListAllSuccess("ExampleLabels=\nExampleOneLine=\nExampleString=\n"),
+				&gofailTestRequest{
+					requestType: "list",
+					request: request{
+						endpoint: "ExampleString",
+						expected: response{
+							statusCode: 404,
+							body:       "failed to GET: failpoint: failpoint is disabled\n\n",
+						},
+					},
+				},
+				&gofailTestRequest{
+					requestType: "count",
+					request: request{
+						endpoint: "ExampleString",
+						expected: response{
+							statusCode: 500,
+							body:       "failed to GET: failpoint: failpoint is disabled\n",
+						},
+					},
+				},
+				rgTestServerSuccess("ExampleFunc", "example"),
+			},
+		},
+		{
+			name: "re-enabling a failpoint resets count",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "put",
+					request: request{
+						endpoint: "ExampleString",
+						args:     []string{"return(\"new fail string\")"},
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				&gofailTestRequest{
+					requestType: "count",
+					request: request{
+						endpoint: "ExampleString",
+						expected: response{
+							statusCode: 200,
+							body:       "0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "failpoints happy path",
+			requests: []testRequest{
+				rgTestServerSuccess("ExampleFunc", "new fail string"),
+				rgTestServerSuccess("ExampleOneLineFunc", "abc"),
+				rgTestServerSuccess("ExampleLabelsFunc", "ijjjjjijjjjjijjjjjijjjjjijjjjj"),
+				&gofailTestRequest{
+					requestType: "failpoints",
+					request: request{
+						args: []string{
+							"ExampleString=1*return(\"fail string1\")->return(\"fail string2\")",
+							"ExampleOneLine=return(\"def\")",
+							"ExampleLabels=return"},
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				rgListAllSuccess(strings.Join([]string{
+					"ExampleString=1*return(\"fail string1\")->return(\"fail string2\")",
+					"ExampleOneLine=return(\"def\")",
+					"ExampleLabels=return"}, "\n") + "\n"),
+				rgCountSuccess("ExampleString", 0),
+				rgTestServerSuccess("ExampleFunc", "fail string1"),
+				rgTestServerSuccess("ExampleFunc", "fail string2"),
+				rgTestServerSuccess("ExampleOneLineFunc", "abc"),
+				rgTestServerSuccess("ExampleLabelsFunc", "ijijijijij"),
+				rgCountSuccess("ExampleString", 2),
+				rgCountSuccess("ExampleOneLine", 1),
+				rgCountSuccess("ExampleLabels", 5),
+			},
+		},
+		{
+			name: "failpoints works with subset of failpoints",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "failpoints",
+					request: request{
+						args: []string{"ExampleOneLine=return(\"ghi\")"},
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				rgListAllSuccess(strings.Join([]string{
+					"ExampleString=1*return(\"fail string1\")->return(\"fail string2\")",
+					"ExampleOneLine=return(\"ghi\")",
+					"ExampleLabels=return"}, "\n") + "\n"),
+				rgCountSuccess("ExampleString", 2),
+				rgCountSuccess("ExampleOneLine", 0),
+				rgCountSuccess("ExampleLabels", 5),
+			},
+		},
+		{
+			name: "failpoints ignores invalid failpoints, and processes valid ones",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "failpoints",
+					request: request{
+						args: []string{
+							"ExampleOneLine=return(\"jkl\")",
+							"InvalidFailpoint=return",
+						},
+						expected: response{
+							statusCode: 400,
+							body:       "fail to set failpoint: failpoint: failpoint does not exist\n",
+						},
+					},
+				},
+				rgListAllSuccess(strings.Join([]string{
+					"ExampleString=1*return(\"fail string1\")->return(\"fail string2\")",
+					"ExampleOneLine=return(\"jkl\")",
+					"ExampleLabels=return"}, "\n") + "\n"),
+				rgCountSuccess("ExampleString", 2),
+				rgCountSuccess("ExampleOneLine", 0),
+				rgCountSuccess("ExampleLabels", 5),
+			},
+		},
+		{
+			name: "failpoints can reset failpoints",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "failpoints",
+					request: request{
+						args: []string{
+							"ExampleString=off",
+							"ExampleOneLine=off",
+							"ExampleLabels=off",
+						},
+						expected: response{
+							statusCode: 204,
+							body:       "",
+						},
+					},
+				},
+				rgListAllSuccess(strings.Join([]string{
+					"ExampleString=off",
+					"ExampleOneLine=off",
+					"ExampleLabels=off",
+				}, "\n") + "\n"),
+				rgTestServerSuccess("ExampleFunc", "example"),
+				rgTestServerSuccess("ExampleOneLineFunc", "abc"),
+				rgTestServerSuccess("ExampleLabelsFunc", "ijjjjjijjjjjijjjjjijjjjjijjjjj"),
+				rgCountSuccess("ExampleString", 1),
+				rgCountSuccess("ExampleOneLine", 1),
+				rgCountSuccess("ExampleLabels", 25),
+			},
+		},
+		{
+			name: "failpoints can't delete failpoints :(",
+			requests: []testRequest{
+				&gofailTestRequest{
+					requestType: "failpoints",
+					request: request{
+						args: []string{
+							"ExampleString=",
+							"ExampleOneLine=",
+							"ExampleLabels=",
+						},
+						expected: response{
+							statusCode: 400,
+							body:       "fail to set failpoint: failpoint: could not parse terms\n",
+						},
+					},
+				},
+				rgListAllSuccess(strings.Join([]string{
+					"ExampleString=off",
+					"ExampleOneLine=off",
+					"ExampleLabels=off",
+				}, "\n") + "\n"),
+				rgTestServerSuccess("ExampleFunc", "example"),
+				rgTestServerSuccess("ExampleOneLineFunc", "abc"),
+				rgTestServerSuccess("ExampleLabelsFunc", "ijjjjjijjjjjijjjjjijjjjjijjjjj"),
+				rgCountSuccess("ExampleString", 2),
+				rgCountSuccess("ExampleOneLine", 2),
+				rgCountSuccess("ExampleLabels", 50),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, req := range test.requests {
+				req.SetupPortAssignments(pas)
+				req.AssertResponse(t)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview
This fixes https://github.com/etcd-io/gofail/issues/40 , hopefully satisfactorily.  The intent here is to make a generic and flexible test harness for exercising the gofail http api.  I've added some obvious basic tests; I'm sure the maintainers can think of more to add in the future.

The code should be pretty self explanatory.  The main explanation of the test setup is in the godoc for `TestAll` in integration/server/server_test.go .

This is my first PR to this repo, and I did my best to follow all the contribution instructions I could find, but please let me know if I missed anything.