### PR TITLE
20250216 bump go linter 1.24

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,7 +27,7 @@ jobs:
         uses: golangci/golangci-lint-action@2e788936b09dd82dc280e845628a40d2ba6b204c # v6.3.1
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.57.1
+          version: v1.64.5
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
https://github.com/etcd-io/gofail/pull/102  CI failure is due to linter version used.

This PR bumps the go-linter version used in CI

@ivanvc @henrybear327